### PR TITLE
Add link to EMPIAR-10164 tutorial

### DIFF
--- a/resources/cryoet-software/peet/peet.md
+++ b/resources/cryoet-software/peet/peet.md
@@ -2,7 +2,7 @@
 
 [PEET](https://bio3d.colorado.edu/peet/) is subtomogram averaging
 package developed and maintained by the University of Colorado at
-at Boulder. PEET is free, open-source, and is supported on Linux, 
+Boulder. PEET is free, open-source, and is supported on Linux, 
 MacOS, and Windows. Please see the link above for binaries, source 
 code, and documentation. For example, subtomogram averaging of the 
 5 tomogram subset of EMPIAR-10164 to near atomic resolution using 

--- a/resources/cryoet-software/peet/peet.md
+++ b/resources/cryoet-software/peet/peet.md
@@ -4,7 +4,10 @@
 package developed and maintained by the University of Colorado at
 at Boulder. PEET is free, open-source, and is supported on Linux, 
 MacOS, and Windows. Please see the link above for binaries, source 
-code, and documentation.
+code, and documentation. For example, subtomogram averaging of the 
+5 tomogram subset of EMPIAR-10164 to near atomic resolution using 
+Imod and PEET is described at
+https://bio3d.colorado.edu/PEET/HiResSTATutorial.pdf.
 
 PEET is distributed as a separate package but integrates with and
 is typically used in conjunction with the 


### PR DESCRIPTION
There's now a PEET / IMOD EMPIAR-10164 tutorial walkthrough on our bio3d website. I added an explicit link from the PEET resource entry.